### PR TITLE
Add timesheet CLI for project management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+timesheet.db
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # projectmgt
-Simple project Management for small team
+
+Simple project management tools for small teams.
+
+## Timesheet CLI
+
+Employees can log hours for projects using the `timesheet.py` script. The
+script uses a local SQLite database called `timesheet.db`.
+
+### Setup
+
+No external dependencies are required. Ensure you have Python 3 installed.
+
+### Usage
+
+Initialize the database and add employees or projects:
+
+```bash
+python timesheet.py add-employee Alice
+python timesheet.py add-project "Awesome Project"
+```
+
+Log hours for a project (date defaults to today):
+
+```bash
+python timesheet.py log Alice "Awesome Project" 3.5
+```
+
+Generate a report for a project:
+
+```bash
+python timesheet.py report "Awesome Project" --start 2023-01-01 --end 2023-01-31
+```
+
+The report lists each entry and totals the hours for the selected period.

--- a/timesheet.py
+++ b/timesheet.py
@@ -1,0 +1,141 @@
+import sqlite3
+import argparse
+from datetime import date
+
+DB_FILE = 'timesheet.db'
+
+
+def init_db():
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        cur.execute('''CREATE TABLE IF NOT EXISTS employees (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL
+        )''')
+        cur.execute('''CREATE TABLE IF NOT EXISTS projects (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL
+        )''')
+        cur.execute('''CREATE TABLE IF NOT EXISTS timesheets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            employee_id INTEGER NOT NULL,
+            project_id INTEGER NOT NULL,
+            entry_date TEXT NOT NULL,
+            hours REAL NOT NULL,
+            FOREIGN KEY (employee_id) REFERENCES employees(id),
+            FOREIGN KEY (project_id) REFERENCES projects(id)
+        )''')
+        conn.commit()
+
+
+def get_or_create(cursor, table, name):
+    cursor.execute(f"SELECT id FROM {table} WHERE name = ?", (name,))
+    row = cursor.fetchone()
+    if row:
+        return row[0]
+    cursor.execute(f"INSERT INTO {table}(name) VALUES(?)", (name,))
+    return cursor.lastrowid
+
+
+def add_employee(args):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        try:
+            get_or_create(cur, 'employees', args.name)
+            conn.commit()
+            print(f"Employee '{args.name}' added")
+        except sqlite3.IntegrityError:
+            print(f"Employee '{args.name}' already exists")
+
+
+def add_project(args):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        try:
+            get_or_create(cur, 'projects', args.name)
+            conn.commit()
+            print(f"Project '{args.name}' added")
+        except sqlite3.IntegrityError:
+            print(f"Project '{args.name}' already exists")
+
+
+def log_time(args):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        emp_id = get_or_create(cur, 'employees', args.employee)
+        proj_id = get_or_create(cur, 'projects', args.project)
+        cur.execute(
+            'INSERT INTO timesheets(employee_id, project_id, entry_date, hours) VALUES (?, ?, ?, ?)',
+            (emp_id, proj_id, args.date, args.hours)
+        )
+        conn.commit()
+        print('Time entry recorded')
+
+
+def report(args):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        query = '''SELECT p.name, e.name, t.entry_date, t.hours
+                   FROM timesheets t
+                   JOIN employees e ON e.id = t.employee_id
+                   JOIN projects p ON p.id = t.project_id
+                   WHERE p.name = ?'''
+        params = [args.project]
+        if args.start:
+            query += ' AND t.entry_date >= ?'
+            params.append(args.start)
+        if args.end:
+            query += ' AND t.entry_date <= ?'
+            params.append(args.end)
+        query += ' ORDER BY t.entry_date, e.name'
+        cur.execute(query, params)
+        rows = cur.fetchall()
+        if not rows:
+            print('No entries found')
+            return
+        total = 0
+        for project, employee, entry_date, hours in rows:
+            print(f"{entry_date} | {employee} | {hours}h")
+            total += hours
+        print(f"Total hours for {args.project}: {total}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Simple timesheet tool')
+    sub = parser.add_subparsers(dest='cmd')
+
+    sub_add_emp = sub.add_parser('add-employee', help='Add a new employee')
+    sub_add_emp.add_argument('name')
+    sub_add_emp.set_defaults(func=add_employee)
+
+    sub_add_proj = sub.add_parser('add-project', help='Add a new project')
+    sub_add_proj.add_argument('name')
+    sub_add_proj.set_defaults(func=add_project)
+
+    sub_log = sub.add_parser('log', help='Log hours for a project')
+    sub_log.add_argument('employee')
+    sub_log.add_argument('project')
+    sub_log.add_argument('hours', type=float)
+    sub_log.add_argument('--date', default=date.today().isoformat())
+    sub_log.set_defaults(func=log_time)
+
+    sub_rep = sub.add_parser('report', help='Show hours for a project')
+    sub_rep.add_argument('project')
+    sub_rep.add_argument('--start')
+    sub_rep.add_argument('--end')
+    sub_rep.set_defaults(func=report)
+
+    return parser.parse_args()
+
+
+def main():
+    init_db()
+    args = parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        print('No command given. Use -h for help.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple CLI tool `timesheet.py` for logging hours
- document usage in README
- ignore database and bytecode files

## Testing
- `python3 -m py_compile timesheet.py`
- `python3 timesheet.py -h | head`

------
https://chatgpt.com/codex/tasks/task_b_685306eb580883218eb7f27b1b7781a5