### PR TITLE
Allow timesheet DB path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Simple project management tools for small teams.
 ## Timesheet CLI
 
 Employees can log hours for projects using the `timesheet.py` script. The
-script uses a local SQLite database called `timesheet.db`.
+script uses a local SQLite database called `timesheet.db` in the script
+directory by default. You can specify a different path with the `--db`
+option.
 
 ### Setup
 


### PR DESCRIPTION
## Summary
- allow specifying the SQLite DB via `--db`
- default DB path to `timesheet.db` in the script folder
- document the new CLI option

## Testing
- `python -m py_compile timesheet.py`
- `python timesheet.py -h | head`

------
https://chatgpt.com/codex/tasks/task_b_685309546eb083218cd6033bdc805bf8