### PR TITLE
Improve log_time validation

### DIFF
--- a/timesheet.py
+++ b/timesheet.py
@@ -1,6 +1,6 @@
 import sqlite3
 import argparse
-from datetime import date
+from datetime import date, datetime
 
 DB_FILE = 'timesheet.db'
 
@@ -60,13 +60,31 @@ def add_project(args):
 
 
 def log_time(args):
+    # Validate hours value
+    if args.hours <= 0 or args.hours > 24:
+        print('Hours must be greater than 0 and no more than 24.')
+        return
+    if args.hours * 2 != int(args.hours * 2):
+        print('Hours must be in 0.5 hour increments.')
+        return
+
+    # Validate date format and ensure it's not in the future
+    try:
+        entry_date = datetime.strptime(args.date, '%Y-%m-%d').date()
+    except ValueError:
+        print('Date must be in YYYY-MM-DD format.')
+        return
+    if entry_date > date.today():
+        print('Date cannot be in the future.')
+        return
+
     with sqlite3.connect(DB_FILE) as conn:
         cur = conn.cursor()
         emp_id = get_or_create(cur, 'employees', args.employee)
         proj_id = get_or_create(cur, 'projects', args.project)
         cur.execute(
             'INSERT INTO timesheets(employee_id, project_id, entry_date, hours) VALUES (?, ?, ?, ?)',
-            (emp_id, proj_id, args.date, args.hours)
+            (emp_id, proj_id, entry_date.isoformat(), args.hours)
         )
         conn.commit()
         print('Time entry recorded')


### PR DESCRIPTION
## Summary
- validate `hours` range and increment in `log_time`
- validate provided date format and future dates

## Testing
- `python -m py_compile timesheet.py`
- `python timesheet.py log Alice "Test" 0`
- `python timesheet.py log Alice "Test" 1.25`
- `python timesheet.py log Alice "Test" 2 --date 2026-01-01`
- `python timesheet.py log Alice "Test" 2 --date 2025/01/01`


------
https://chatgpt.com/codex/tasks/task_b_685309493c448321a1d4ef5f0ceba0d5