### PR TITLE
Add update and delete functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ python timesheet.py report "Awesome Project" --start 2023-01-01 --end 2023-01-31
 ```
 
 The report lists each entry and totals the hours for the selected period.
+
+Update or delete a time entry:
+
+```bash
+# update by id
+python timesheet.py update --id 1 --new-hours 4
+
+# or locate by employee, project and date
+python timesheet.py update --employee Alice --project "Awesome Project" \
+  --entry-date 2023-02-01 --new-date 2023-02-02
+
+# delete an entry
+python timesheet.py delete --id 1
+```

--- a/timesheet.py
+++ b/timesheet.py
@@ -100,6 +100,67 @@ def report(args):
         print(f"Total hours for {args.project}: {total}")
 
 
+def _find_entry(cur, entry_id=None, employee=None, project=None, entry_date=None):
+    """Return the id of the entry matching the given criteria."""
+    if entry_id:
+        cur.execute('SELECT id FROM timesheets WHERE id = ?', (entry_id,))
+        row = cur.fetchone()
+        return row[0] if row else None
+    if employee and project and entry_date:
+        cur.execute(
+            '''SELECT t.id FROM timesheets t
+               JOIN employees e ON e.id = t.employee_id
+               JOIN projects p ON p.id = t.project_id
+               WHERE e.name = ? AND p.name = ? AND t.entry_date = ?''',
+            (employee, project, entry_date),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+    return None
+
+
+def update_time(args):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        entry_id = _find_entry(
+            cur, args.id, args.employee, args.project, args.entry_date
+        )
+        if not entry_id:
+            print('Entry not found')
+            return
+        updates = []
+        params = []
+        if args.new_hours is not None:
+            updates.append('hours = ?')
+            params.append(args.new_hours)
+        if args.new_date:
+            updates.append('entry_date = ?')
+            params.append(args.new_date)
+        if not updates:
+            print('No updates specified')
+            return
+        params.append(entry_id)
+        cur.execute(
+            f'UPDATE timesheets SET {", ".join(updates)} WHERE id = ?', params
+        )
+        conn.commit()
+        print(f'Entry {entry_id} updated')
+
+
+def delete_time(args):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        entry_id = _find_entry(
+            cur, args.id, args.employee, args.project, args.entry_date
+        )
+        if not entry_id:
+            print('Entry not found')
+            return
+        cur.execute('DELETE FROM timesheets WHERE id = ?', (entry_id,))
+        conn.commit()
+        print(f'Entry {entry_id} deleted')
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description='Simple timesheet tool')
     sub = parser.add_subparsers(dest='cmd')
@@ -124,6 +185,22 @@ def parse_args():
     sub_rep.add_argument('--start')
     sub_rep.add_argument('--end')
     sub_rep.set_defaults(func=report)
+
+    sub_upd = sub.add_parser('update', help='Update a time entry')
+    sub_upd.add_argument('--id', type=int, help='Entry ID')
+    sub_upd.add_argument('--employee', help='Employee name')
+    sub_upd.add_argument('--project', help='Project name')
+    sub_upd.add_argument('--entry-date', help='Original entry date')
+    sub_upd.add_argument('--new-hours', type=float, help='Updated hours')
+    sub_upd.add_argument('--new-date', help='Updated date')
+    sub_upd.set_defaults(func=update_time)
+
+    sub_del = sub.add_parser('delete', help='Delete a time entry')
+    sub_del.add_argument('--id', type=int, help='Entry ID')
+    sub_del.add_argument('--employee', help='Employee name')
+    sub_del.add_argument('--project', help='Project name')
+    sub_del.add_argument('--entry-date', help='Entry date')
+    sub_del.set_defaults(func=delete_time)
 
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- add `_find_entry` helper to look up timesheet rows
- implement `update_time` and `delete_time`
- extend CLI argument parser with `update` and `delete` commands
- document new commands in the README

## Testing
- `python -m py_compile timesheet.py`
- `python timesheet.py -h | head`
- `python timesheet.py update -h`
- `python timesheet.py delete -h`

------
https://chatgpt.com/codex/tasks/task_b_6853095818c483219b125fb2b1759568