### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,16 @@
+name: Python Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run tests
+        run: |
+          python -m unittest discover -s tests

--- a/tests/test_timesheet.py
+++ b/tests/test_timesheet.py
@@ -1,0 +1,68 @@
+import os
+import sqlite3
+import io
+import tempfile
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+import unittest
+
+import timesheet
+
+class TimesheetTests(unittest.TestCase):
+    def setUp(self):
+        # Use a temporary database file for each test
+        self.db_fd, self.db_path = None, None
+        self.db_fd, self.db_path = tempfile.mkstemp()
+        self.orig_db = timesheet.DB_FILE
+        timesheet.DB_FILE = self.db_path
+        timesheet.init_db()
+
+    def tearDown(self):
+        if self.db_fd:
+            os.close(self.db_fd)
+        if self.db_path and os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        timesheet.DB_FILE = self.orig_db
+
+    def test_init_db_creates_tables(self):
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = {row[0] for row in cur.fetchall()}
+        expected = {'employees', 'projects', 'timesheets'}
+        self.assertTrue(expected.issubset(tables))
+
+    def test_log_time_records_entry(self):
+        args = SimpleNamespace(employee='Alice', project='Proj', hours=2.0, date='2023-01-01')
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            timesheet.log_time(args)
+        output = buf.getvalue()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM timesheets")
+            count = cur.fetchone()[0]
+        self.assertEqual(count, 1)
+        self.assertIn('Time entry recorded', output)
+
+    def test_report_outputs_entries(self):
+        # Add two entries
+        args = SimpleNamespace(employee='Alice', project='Proj', hours=2.0, date='2023-01-01')
+        with redirect_stdout(io.StringIO()):
+            timesheet.log_time(args)
+        args = SimpleNamespace(employee='Bob', project='Proj', hours=1.5, date='2023-01-02')
+        with redirect_stdout(io.StringIO()):
+            timesheet.log_time(args)
+
+        rep_args = SimpleNamespace(project='Proj', start=None, end=None)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            timesheet.report(rep_args)
+        output = buf.getvalue()
+        self.assertIn('Total hours for Proj: 3.5', output)
+        self.assertIn('Alice', output)
+        self.assertIn('Bob', output)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add `unittest` tests for DB init, logging and reports
- create GitHub Actions workflow to run tests

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_b_6853095f1f7c8321bea3a385c75d0c04