### PR TITLE
Add summary flag for timesheet reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,10 @@ Generate a report for a project:
 python timesheet.py report "Awesome Project" --start 2023-01-01 --end 2023-01-31
 ```
 
-The report lists each entry and totals the hours for the selected period.
+The report lists each entry and totals the hours for the selected period. Use
+`--summary` to group totals by employee or date:
+
+```bash
+python timesheet.py report "Awesome Project" --summary employee
+python timesheet.py report "Awesome Project" --summary date --start 2023-01-01 --end 2023-01-31
+```


### PR DESCRIPTION
## Summary
- allow grouping timesheet report output via `--summary`
- group by employee or date when the flag is used
- document summary examples

## Testing
- `python -m py_compile timesheet.py`
- `python timesheet.py report Example --summary employee`
- `python timesheet.py report Example --summary date`


------
https://chatgpt.com/codex/tasks/task_b_6853095ca9ac832195d4fae97ea49090