### PR TITLE
Improve error handling for DB access

### DIFF
--- a/timesheet.py
+++ b/timesheet.py
@@ -1,31 +1,45 @@
 import sqlite3
 import argparse
+import sys
 from datetime import date
 
 DB_FILE = 'timesheet.db'
 
 
+def connect_db():
+    """Return a connection to the SQLite database or exit on failure."""
+    try:
+        return sqlite3.connect(DB_FILE)
+    except sqlite3.Error as e:
+        print(f"Could not open database '{DB_FILE}': {e}")
+        sys.exit(1)
+
+
 def init_db():
-    with sqlite3.connect(DB_FILE) as conn:
-        cur = conn.cursor()
-        cur.execute('''CREATE TABLE IF NOT EXISTS employees (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT UNIQUE NOT NULL
-        )''')
-        cur.execute('''CREATE TABLE IF NOT EXISTS projects (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT UNIQUE NOT NULL
-        )''')
-        cur.execute('''CREATE TABLE IF NOT EXISTS timesheets (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            employee_id INTEGER NOT NULL,
-            project_id INTEGER NOT NULL,
-            entry_date TEXT NOT NULL,
-            hours REAL NOT NULL,
-            FOREIGN KEY (employee_id) REFERENCES employees(id),
-            FOREIGN KEY (project_id) REFERENCES projects(id)
-        )''')
-        conn.commit()
+    try:
+        with connect_db() as conn:
+            cur = conn.cursor()
+            cur.execute('''CREATE TABLE IF NOT EXISTS employees (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )''')
+            cur.execute('''CREATE TABLE IF NOT EXISTS projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )''')
+            cur.execute('''CREATE TABLE IF NOT EXISTS timesheets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                employee_id INTEGER NOT NULL,
+                project_id INTEGER NOT NULL,
+                entry_date TEXT NOT NULL,
+                hours REAL NOT NULL,
+                FOREIGN KEY (employee_id) REFERENCES employees(id),
+                FOREIGN KEY (project_id) REFERENCES projects(id)
+            )''')
+            conn.commit()
+    except sqlite3.Error as e:
+        print(f"Database initialization failed: {e}")
+        sys.exit(1)
 
 
 def get_or_create(cursor, table, name):
@@ -38,7 +52,7 @@ def get_or_create(cursor, table, name):
 
 
 def add_employee(args):
-    with sqlite3.connect(DB_FILE) as conn:
+    with connect_db() as conn:
         cur = conn.cursor()
         try:
             get_or_create(cur, 'employees', args.name)
@@ -46,10 +60,13 @@ def add_employee(args):
             print(f"Employee '{args.name}' added")
         except sqlite3.IntegrityError:
             print(f"Employee '{args.name}' already exists")
+        except sqlite3.Error as e:
+            print(f"Failed to add employee: {e}")
+            sys.exit(1)
 
 
 def add_project(args):
-    with sqlite3.connect(DB_FILE) as conn:
+    with connect_db() as conn:
         cur = conn.cursor()
         try:
             get_or_create(cur, 'projects', args.name)
@@ -57,47 +74,58 @@ def add_project(args):
             print(f"Project '{args.name}' added")
         except sqlite3.IntegrityError:
             print(f"Project '{args.name}' already exists")
+        except sqlite3.Error as e:
+            print(f"Failed to add project: {e}")
+            sys.exit(1)
 
 
 def log_time(args):
-    with sqlite3.connect(DB_FILE) as conn:
+    with connect_db() as conn:
         cur = conn.cursor()
-        emp_id = get_or_create(cur, 'employees', args.employee)
-        proj_id = get_or_create(cur, 'projects', args.project)
-        cur.execute(
-            'INSERT INTO timesheets(employee_id, project_id, entry_date, hours) VALUES (?, ?, ?, ?)',
-            (emp_id, proj_id, args.date, args.hours)
-        )
-        conn.commit()
-        print('Time entry recorded')
+        try:
+            emp_id = get_or_create(cur, 'employees', args.employee)
+            proj_id = get_or_create(cur, 'projects', args.project)
+            cur.execute(
+                'INSERT INTO timesheets(employee_id, project_id, entry_date, hours) VALUES (?, ?, ?, ?)',
+                (emp_id, proj_id, args.date, args.hours)
+            )
+            conn.commit()
+            print('Time entry recorded')
+        except sqlite3.Error as e:
+            print(f"Failed to log time: {e}")
+            sys.exit(1)
 
 
 def report(args):
-    with sqlite3.connect(DB_FILE) as conn:
+    with connect_db() as conn:
         cur = conn.cursor()
-        query = '''SELECT p.name, e.name, t.entry_date, t.hours
-                   FROM timesheets t
-                   JOIN employees e ON e.id = t.employee_id
-                   JOIN projects p ON p.id = t.project_id
-                   WHERE p.name = ?'''
-        params = [args.project]
-        if args.start:
-            query += ' AND t.entry_date >= ?'
-            params.append(args.start)
-        if args.end:
-            query += ' AND t.entry_date <= ?'
-            params.append(args.end)
-        query += ' ORDER BY t.entry_date, e.name'
-        cur.execute(query, params)
-        rows = cur.fetchall()
-        if not rows:
-            print('No entries found')
-            return
-        total = 0
-        for project, employee, entry_date, hours in rows:
-            print(f"{entry_date} | {employee} | {hours}h")
-            total += hours
-        print(f"Total hours for {args.project}: {total}")
+        try:
+            query = '''SELECT p.name, e.name, t.entry_date, t.hours
+                       FROM timesheets t
+                       JOIN employees e ON e.id = t.employee_id
+                       JOIN projects p ON p.id = t.project_id
+                       WHERE p.name = ?'''
+            params = [args.project]
+            if args.start:
+                query += ' AND t.entry_date >= ?'
+                params.append(args.start)
+            if args.end:
+                query += ' AND t.entry_date <= ?'
+                params.append(args.end)
+            query += ' ORDER BY t.entry_date, e.name'
+            cur.execute(query, params)
+            rows = cur.fetchall()
+            if not rows:
+                print('No entries found')
+                return
+            total = 0
+            for project, employee, entry_date, hours in rows:
+                print(f"{entry_date} | {employee} | {hours}h")
+                total += hours
+            print(f"Total hours for {args.project}: {total}")
+        except sqlite3.Error as e:
+            print(f"Failed to run report: {e}")
+            sys.exit(1)
 
 
 def parse_args():


### PR DESCRIPTION
## Summary
- exit with a meaningful message when the SQLite DB cannot be opened
- print informative errors if initialization or queries fail

## Testing
- `python -m py_compile timesheet.py`
- `python timesheet.py -h | head`

------
https://chatgpt.com/codex/tasks/task_b_685309613edc83219ad22f4c374c4de6