### PR TITLE
Improve CLI docs and add db path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,67 @@ python timesheet.py report "Awesome Project" --start 2023-01-01 --end 2023-01-31
 ```
 
 The report lists each entry and totals the hours for the selected period.
+
+### Commands
+
+Below is a summary of the available commands. Use `-h` with any command for
+help on its options.
+
+#### `add-employee`
+
+Adds a new employee to the database.
+
+```bash
+python timesheet.py add-employee <name>
+```
+
+#### `add-project`
+
+Registers a project so employees can log time against it.
+
+```bash
+python timesheet.py add-project "<project name>"
+```
+
+#### `log`
+
+Records hours for an employee on a project. The date defaults to today and can
+be overridden with the `--date` option (format: `YYYY-MM-DD`).
+
+```bash
+python timesheet.py log <employee> "<project>" <hours> [--date YYYY-MM-DD]
+```
+
+#### `report`
+
+Displays all recorded entries for a project. Use `--start` and `--end` to limit
+the date range.
+
+```bash
+python timesheet.py report "<project>" [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+```
+
+### Database location
+
+By default the CLI stores data in a file named `timesheet.db` located in the
+current working directory. You can change this location by either setting the
+`TIMESHEET_DB` environment variable or using the global `--db` option:
+
+```bash
+# Use an environment variable
+export TIMESHEET_DB=/path/to/my.db
+
+# Or pass the path for a single invocation
+python timesheet.py --db /path/to/my.db add-employee Alice
+```
+
+### Troubleshooting
+
+* **Employee or project already exists** – The CLI prints an error if you try to
+  add a duplicate entry. Use a different name or remove the existing record
+  directly from the database.
+* **"No command given" message** – Make sure you specify one of the commands
+  (`add-employee`, `add-project`, `log`, or `report`). Run `python timesheet.py
+  -h` to see available options.
+* **"No entries found" when generating a report** – Check that you logged time
+  for the correct project and date range.

--- a/timesheet.py
+++ b/timesheet.py
@@ -1,8 +1,9 @@
 import sqlite3
 import argparse
+import os
 from datetime import date
 
-DB_FILE = 'timesheet.db'
+DB_FILE = os.environ.get('TIMESHEET_DB', 'timesheet.db')
 
 
 def init_db():
@@ -102,6 +103,8 @@ def report(args):
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Simple timesheet tool')
+    parser.add_argument('--db', default=DB_FILE,
+                        help='Path to the SQLite database file')
     sub = parser.add_subparsers(dest='cmd')
 
     sub_add_emp = sub.add_parser('add-employee', help='Add a new employee')
@@ -129,8 +132,10 @@ def parse_args():
 
 
 def main():
-    init_db()
     args = parse_args()
+    global DB_FILE
+    DB_FILE = args.db
+    init_db()
     if hasattr(args, 'func'):
         args.func(args)
     else:


### PR DESCRIPTION
## Summary
- document each command with usage examples
- document database location and custom path option
- add troubleshooting tips to README
- allow specifying custom db path via `--db` or `TIMESHEET_DB`

## Testing
- `python -m py_compile timesheet.py`

------
https://chatgpt.com/codex/tasks/task_b_685309673d6c832185863ae92a8a63d3