### PR TITLE
Handle duplicate entries

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -14,11 +14,11 @@ def add_employee(name):
     try:
         with timesheet.connect_db() as conn:
             cur = conn.cursor()
-            timesheet.get_or_create(cur, 'employees', name)
-            conn.commit()
-        return True, f"Employee '{name}' added"
-    except sqlite3.IntegrityError:
-        return False, f"Employee '{name}' already exists"
+            _, created = timesheet.get_or_create(cur, 'employees', name)
+            if created:
+                conn.commit()
+                return True, f"Employee '{name}' added"
+            return False, f"Employee '{name}' already exists"
     except sqlite3.Error as e:
         return False, f"Failed to add employee: {e}"
 
@@ -27,11 +27,11 @@ def add_project(name):
     try:
         with timesheet.connect_db() as conn:
             cur = conn.cursor()
-            timesheet.get_or_create(cur, 'projects', name)
-            conn.commit()
-        return True, f"Project '{name}' added"
-    except sqlite3.IntegrityError:
-        return False, f"Project '{name}' already exists"
+            _, created = timesheet.get_or_create(cur, 'projects', name)
+            if created:
+                conn.commit()
+                return True, f"Project '{name}' added"
+            return False, f"Project '{name}' already exists"
     except sqlite3.Error as e:
         return False, f"Failed to add project: {e}"
 


### PR DESCRIPTION
## Summary
- handle duplicates by detecting insert vs existing record
- update CLI and web helpers to use new return value

## Testing
- `pytest -q`
- `python timesheet.py add-employee Alice`
- `python timesheet.py add-employee Alice`

------
https://chatgpt.com/codex/tasks/task_b_6853310ac22083219e54bbdbac355695