### PR TITLE
Add employee login with timesheet entry UI

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+    <title>Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#eef; padding:40px; }
+        a.button { display:inline-block; padding:10px 15px; background:#007bff; color:white; text-decoration:none; border-radius:4px; }
+    </style>
+</head>
+<body>
+    <h1>Welcome {{ employee }}</h1>
+    <p><a class="button" href="{{ url_for('timesheet_entry') }}">Timesheet Entry</a></p>
+    <p><a href="{{ url_for('logout') }}">Logout</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
     <ul>
         <li><a href="/employee">User Master</a></li>
         <li><a href="/project">Project Master</a></li>
+        <li><a href="/login">Employee Login</a></li>
     </ul>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+    <title>Employee Login</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f0f0f0; }
+        .container { width:300px; margin:80px auto; padding:20px; background:#fff; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.1); }
+        input[type=text], input[type=submit] { width:100%; padding:8px; margin-top:10px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>Login</h2>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <ul>
+        {% for category, message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    <form method="post">
+        <input type="text" name="name" placeholder="Employee Name" required>
+        <input type="submit" value="Login">
+    </form>
+</div>
+</body>
+</html>

--- a/templates/timesheet_form.html
+++ b/templates/timesheet_form.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+    <title>Timesheet Entry</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f5f5f5; padding:40px; }
+        form { background:#fff; padding:20px; border-radius:8px; width:320px; margin:auto; box-shadow:0 0 10px rgba(0,0,0,0.1); }
+        input, label { display:block; width:100%; margin-top:10px; }
+        input[type=submit] { margin-top:20px; }
+    </style>
+</head>
+<body>
+    <h1>Timesheet Entry</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <ul>
+        {% for category, message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    <form method="post">
+        <label>Project</label>
+        <input type="text" name="project" required>
+        <label>Hours</label>
+        <input type="number" name="hours" step="0.5" min="0.5" max="24" required>
+        <label>Date</label>
+        <input type="date" name="entry_date" required>
+        <input type="submit" value="Log Time">
+    </form>
+    <p><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow employees to login and persist their name in a session
- add dashboard and timesheet entry form
- create new templates for login, dashboard and the timesheet UI
- link login page from the home page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685334a191308321872ec40c7431cd65