### PR TITLE
Add summary feature and manager interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Displays recorded entries for a project. Use `--start` and `--end` to limit the 
 python timesheet.py report "<project>" [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--summary employee|date]
 ```
 
+#### `summary`
+
+Displays aggregated hours grouped by project or employee. Optional `--period`
+can break down results daily, weekly or monthly.
+
+```bash
+python timesheet.py summary --by project --period monthly --start 2023-01-01
+```
+
 #### `update`
 
 Updates an existing entry. Identify the entry by `--id` or by employee, project and date.
@@ -130,6 +139,6 @@ python timesheet.py --db /path/to/my.db add-employee Alice
 ### Troubleshooting
 
 * **Employee or project already exists** – The CLI prints an error if you try to add a duplicate entry. Use a different name or remove the existing record directly from the database.
-* **"No command given" message** – Make sure you specify one of the commands (`add-employee`, `add-project`, `log`, `report`, `update`, or `delete`). Run `python timesheet.py -h` to see available options.
+* **"No command given" message** – Make sure you specify one of the commands (`add-employee`, `add-project`, `log`, `report`, `summary`, `update`, or `delete`). Run `python timesheet.py -h` to see available options.
 * **"No entries found" when generating a report** – Check that you logged time for the correct project and date range.
 * **"table timesheets has no column named remarks" error** – If you see this message, your database was created with an older version of the tool. Running any command will upgrade the database schema automatically.

--- a/templates/manager_summary.html
+++ b/templates/manager_summary.html
@@ -1,0 +1,10 @@
+{% extends 'index.html' %}
+{% block content %}
+<h1>Project Summary</h1>
+<table>
+  <tr><th>Project</th><th>Total Hours</th></tr>
+  {% for name, hours in data %}
+  <tr><td>{{ name }}</td><td>{{ hours }}</td></tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/tests/test_timesheet.py
+++ b/tests/test_timesheet.py
@@ -89,6 +89,22 @@ class TimesheetTests(unittest.TestCase):
         self.assertIn('Alice', output)
         self.assertIn('Bob', output)
 
+    def test_summary_project_totals(self):
+        args = SimpleNamespace(employee='Alice', project='ProjA', hours=2.0, date='2023-01-01')
+        with redirect_stdout(io.StringIO()):
+            timesheet.log_time(args)
+        args = SimpleNamespace(employee='Bob', project='ProjA', hours=1.5, date='2023-01-02')
+        with redirect_stdout(io.StringIO()):
+            timesheet.log_time(args)
+
+        sum_args = SimpleNamespace(by='project', period=None, start=None, end=None)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            timesheet.summary(sum_args)
+        output = buf.getvalue()
+        self.assertIn('ProjA', output)
+        self.assertIn('3.5h', output)
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
## Summary
- add `summary` command in `timesheet.py` for aggregated hours
- support new CLI arguments in `parse_args`
- add manager summary template and Flask routes
- expose simple payroll API endpoint
- update README with new command details
- test project summary functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68533cb2b23c8321b25231dac9fae715