### PR TITLE
Add user management form

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ Simple project management tools for small teams.
 
 ## Web Interface
 
-A minimal Flask application provides HTML forms for managing employees and
-projects. Install Flask and run the app with `python web_app.py` then open
+A minimal Flask application provides HTML forms for managing users, employees
+and projects. Install Flask and run the app with `python web_app.py` then open
 `http://localhost:5000` in your browser.
+
+The home page links to a **User Master** form where administrators can create
+user accounts with details like email, department and role. Passwords are stored
+hashed for security.
 
 ```bash
 pip install flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,8 @@
 <body>
     <h1>Project Management</h1>
     <ul>
-        <li><a href="/employee">User Master</a></li>
+        <li><a href="/user">User Master</a></li>
+        <li><a href="/employee">Employee Master</a></li>
         <li><a href="/project">Project Master</a></li>
         <li><a href="/login">Employee Login</a></li>
     </ul>

--- a/templates/user_form.html
+++ b/templates/user_form.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html>
+<head>
+    <title>User Master Entry</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f5f5f5; padding:40px; }
+        form { background:#fff; padding:20px; border-radius:8px; width:700px; margin:auto; box-shadow:0 0 10px rgba(0,0,0,0.1); }
+        .grid { display:flex; flex-wrap:wrap; }
+        .grid div { width:50%; padding:5px; box-sizing:border-box; }
+        input, select { width:100%; }
+        .actions { text-align:center; margin-top:20px; }
+    </style>
+</head>
+<body>
+<h1>User Master Entry</h1>
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <ul>
+    {% for category, message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
+<form method="post">
+  <div class="grid">
+    <div>
+      <label>Full Name:</label>
+      <input type="text" name="full_name" required>
+    </div>
+    <div>
+      <label>Phone:</label>
+      <input type="text" name="phone">
+    </div>
+    <div>
+      <label>Email:</label>
+      <input type="email" name="email" required>
+    </div>
+    <div>
+      <label>Designation:</label>
+      <input type="text" name="designation">
+    </div>
+    <div>
+      <label>Username:</label>
+      <input type="text" name="username" required>
+    </div>
+    <div>
+      <label>Password:</label>
+      <input type="password" name="password" required>
+    </div>
+    <div>
+      <label>Department:</label>
+      <select name="department" required>
+        <option value="">Select</option>
+        <option>Development</option>
+        <option>QA</option>
+        <option>HR</option>
+        <option>Management</option>
+      </select>
+    </div>
+    <div>
+      <label>Status:</label>
+      <select name="status" required>
+        <option>Active</option>
+        <option>Inactive</option>
+        <option>Terminated</option>
+      </select>
+    </div>
+    <div>
+      <label>Role:</label>
+      <select name="role" required>
+        <option>Admin</option>
+        <option>Project Manager</option>
+        <option>Employee</option>
+      </select>
+    </div>
+    <div>
+      <label>Reporting Manager:</label>
+      <select name="reporting_manager">
+        <option value="">--None--</option>
+        {% for m in managers %}
+        <option value="{{ m[0] }}">{{ m[1] }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label>Date of Joining:</label>
+      <input type="date" name="date_of_joining">
+    </div>
+  </div>
+  <div class="actions">
+    <input type="submit" value="Save">
+    <input type="reset" value="Reset">
+    <a href="/">Cancel</a>
+  </div>
+</form>
+</body>
+</html>

--- a/timesheet.py
+++ b/timesheet.py
@@ -38,6 +38,24 @@ def init_db(db_file=None):
                 )'''
             )
             cur.execute(
+                '''CREATE TABLE IF NOT EXISTS users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT UNIQUE,
+                    full_name TEXT NOT NULL,
+                    email TEXT UNIQUE NOT NULL,
+                    phone TEXT,
+                    username TEXT UNIQUE NOT NULL,
+                    password TEXT NOT NULL,
+                    department TEXT NOT NULL,
+                    designation TEXT,
+                    role TEXT NOT NULL,
+                    date_of_joining TEXT,
+                    status TEXT NOT NULL,
+                    reporting_manager INTEGER,
+                    FOREIGN KEY (reporting_manager) REFERENCES users(id)
+                )'''
+            )
+            cur.execute(
                 '''CREATE TABLE IF NOT EXISTS timesheets (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     employee_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- extend DB schema with a `users` table
- implement helper functions and `/user` route in web app
- add new User Master HTML form
- link to the form from the home page
- document the new feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68533ea2837c83218d55eca43ba10025