### PR TITLE
Add role-based dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,12 +4,59 @@
     <title>Dashboard</title>
     <style>
         body { font-family: Arial, sans-serif; background:#eef; padding:40px; }
-        a.button { display:inline-block; padding:10px 15px; background:#007bff; color:white; text-decoration:none; border-radius:4px; }
+        .card { background:#fff; padding:15px; margin-bottom:15px; border-radius:5px; box-shadow:0 0 5px rgba(0,0,0,0.1); }
+        table { width:100%; border-collapse:collapse; }
+        th, td { padding:8px; text-align:left; border-bottom:1px solid #ddd; }
+        a.button { display:inline-block; padding:8px 12px; background:#007bff; color:white; text-decoration:none; border-radius:4px; }
     </style>
 </head>
 <body>
-    <h1>Welcome {{ employee }}</h1>
-    <p><a class="button" href="{{ url_for('timesheet_entry') }}">Timesheet Entry</a></p>
+    <h1>Welcome {{ employee }} ({{ role }})</h1>
+
+    {% if role == 'Admin' %}
+    <div class="card">
+        <h2>Admin Overview</h2>
+        <p>Total Projects: {{ totals.projects }}</p>
+        <p>Total Employees: {{ totals.employees }}</p>
+        <p>Timesheets Submitted Today: {{ totals.today_entries }}</p>
+        <p>Pending Approvals: {{ totals.pending_approvals }}</p>
+        <p><a class="button" href="{{ url_for('project_master') }}">Create Project</a></p>
+        <p><a class="button" href="{{ url_for('user_master') }}">Create User</a></p>
+    </div>
+    {% elif role == 'Project Manager' %}
+    <div class="card">
+        <h2>Projects Managed</h2>
+        <p>{{ manager.projects_managed }}</p>
+        <p>Employee Submissions Today: {{ manager.employee_submissions }}</p>
+        <p>Timesheet Review Alerts: {{ manager.review_alerts }}</p>
+        <h3>Project Time Allocation</h3>
+        <table>
+            <tr><th>Project</th><th>Total Hours</th></tr>
+            {% for name, hrs in manager.chart_data %}
+            <tr><td>{{ name }}</td><td>{{ hrs }}</td></tr>
+            {% endfor %}
+        </table>
+    </div>
+    {% else %}
+    <div class="card">
+        <h2>Your Projects</h2>
+        <ul>
+            {% for proj in employee_view.assigned_projects %}
+            <li>{{ proj }}</li>
+            {% endfor %}
+        </ul>
+        <h3>Timesheets This Week</h3>
+        <table>
+            <tr><th>Date</th><th>Hours</th></tr>
+            {% for dt, hrs in employee_view.week_entries %}
+            <tr><td>{{ dt }}</td><td>{{ hrs }}</td></tr>
+            {% endfor %}
+        </table>
+        <p>Submission Today: {{ 'Yes' if employee_view.submitted_today else 'No' }}</p>
+        <p><a class="button" href="{{ url_for('timesheet_entry') }}">Enter Timesheet</a></p>
+    </div>
+    {% endif %}
+
     <p><a href="{{ url_for('logout') }}">Logout</a></p>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,7 +5,11 @@
     <style>
         body { font-family: Arial, sans-serif; background:#f0f0f0; }
         .container { width:300px; margin:80px auto; padding:20px; background:#fff; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.1); }
-        input[type=text], input[type=submit] { width:100%; padding:8px; margin-top:10px; }
+        input[type=text], select, input[type=submit] {
+            width:100%;
+            padding:8px;
+            margin-top:10px;
+        }
     </style>
 </head>
 <body>
@@ -22,6 +26,11 @@
     {% endwith %}
     <form method="post">
         <input type="text" name="name" placeholder="Employee Name" required>
+        <select name="role" required>
+            <option value="Employee">Employee</option>
+            <option value="Project Manager">Project Manager</option>
+            <option value="Admin">Admin</option>
+        </select>
         <input type="submit" value="Login">
     </form>
 </div>


### PR DESCRIPTION
## Summary
- enhance login to collect role information
- build role-aware dashboard with admin/manager/employee sections
- update logout to clear role from session
- style updates to login page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685341f28b808321bb64924151040367