### PR TITLE
Fix logout redirect and add test

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,25 @@
+import unittest
+from web_app import app
+from flask import session
+
+class LogoutTests(unittest.TestCase):
+    def setUp(self):
+        app.config['TESTING'] = True
+        self.client = app.test_client()
+
+    def test_logout_clears_session_and_redirects(self):
+        # Set session values to simulate logged in user
+        with self.client.session_transaction() as sess:
+            sess['employee'] = 'Alice'
+            sess['role'] = 'Admin'
+
+        response = self.client.get('/logout')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login', response.headers['Location'])
+
+        with self.client.session_transaction() as sess:
+            self.assertNotIn('employee', sess)
+            self.assertNotIn('role', sess)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/web_app.py
+++ b/web_app.py
@@ -364,9 +364,9 @@ def login():
 
 @app.route('/logout')
 def logout():
-    session.pop('employee', None)
-    session.pop('role', None)
-    return redirect(url_for('index'))
+    """Clear the current session and return to the login page."""
+    session.clear()
+    return redirect(url_for('login'))
 
 
 @app.route('/dashboard')


### PR DESCRIPTION
## Summary
- redirect to login page when logging out
- clear the session on logout
- add regression test for logout endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685347a91f34832190a1103af8d4e6b3