### PR TITLE
Add manager summary chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The home page links to a **User Master** form where administrators can create
 user accounts with details like email, department and role. Passwords are stored
 hashed for security.
 
+Project managers can view project hours at `/manager/summary`. The page shows a
+bar chart of the top 10 projects by total time and includes a date range filter.
+
 ```bash
 pip install flask
 python web_app.py

--- a/templates/base_dashboard.html
+++ b/templates/base_dashboard.html
@@ -9,7 +9,7 @@
                 <li class="nav-item"><a class="nav-link" href="#">History</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('project_master') }}">Project Master</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('user_master') }}">User Master</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Reports</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('manager_summary') }}">Reports</a></li>
             </ul>
         </div>
     </nav>

--- a/templates/manager_summary.html
+++ b/templates/manager_summary.html
@@ -1,10 +1,45 @@
-{% extends 'index.html' %}
+{% extends 'base_dashboard.html' %}
+{% block title %}Project Summary{% endblock %}
 {% block content %}
-<h1>Project Summary</h1>
-<table>
-  <tr><th>Project</th><th>Total Hours</th></tr>
-  {% for name, hours in data %}
-  <tr><td>{{ name }}</td><td>{{ hours }}</td></tr>
-  {% endfor %}
-</table>
+<h3 class="mb-4">Project Hours</h3>
+<form method="get" class="row g-3 mb-4">
+  <div class="col-auto">
+    <label class="form-label">From Date</label>
+    <input type="date" name="start" value="{{ start }}" class="form-control">
+  </div>
+  <div class="col-auto">
+    <label class="form-label">To Date</label>
+    <input type="date" name="end" value="{{ end }}" class="form-control">
+  </div>
+  <div class="col-auto align-self-end">
+    <button type="submit" class="btn btn-primary">Filter</button>
+  </div>
+</form>
+<div class="card">
+  <div class="card-body">
+    <div style="height:400px">
+      <canvas id="hoursChart"></canvas>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const ctx = document.getElementById('hoursChart').getContext('2d');
+new Chart(ctx, {
+  type: 'bar',
+  data: {
+    labels: {{ labels|tojson }},
+    datasets: [{
+      label: 'Total Hours',
+      data: {{ hours|tojson }},
+      backgroundColor: 'rgba(54, 162, 235, 0.6)'
+    }]
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: { y: { beginAtZero: true } }
+  }
+});
+</script>
 {% endblock %}

--- a/web_app.py
+++ b/web_app.py
@@ -231,7 +231,7 @@ def project_summary(start=None, end=None):
     with timesheet.connect_db() as conn:
         cur = conn.cursor()
         query = (
-            'SELECT p.name, SUM(t.hours) FROM timesheets t '
+            'SELECT p.name, SUM(t.hours) AS total_hours FROM timesheets t '
             'JOIN projects p ON p.id = t.project_id WHERE 1=1'
         )
         params = []
@@ -241,7 +241,7 @@ def project_summary(start=None, end=None):
         if end:
             query += ' AND t.entry_date <= ?'
             params.append(end)
-        query += ' GROUP BY p.name ORDER BY p.name'
+        query += ' GROUP BY p.name ORDER BY total_hours DESC LIMIT 10'
         cur.execute(query, params)
         return cur.fetchall()
 
@@ -426,7 +426,16 @@ def manager_summary():
     start = request.args.get('start')
     end = request.args.get('end')
     data = project_summary(start, end)
-    return render_template('manager_summary.html', data=data, start=start, end=end)
+    labels = [row[0] for row in data]
+    hours = [row[1] for row in data]
+    return render_template(
+        'manager_summary.html',
+        data=data,
+        labels=labels,
+        hours=hours,
+        start=start,
+        end=end,
+    )
 
 
 @app.route('/api/payroll')


### PR DESCRIPTION
## Summary
- chart top 10 projects by total hours
- link Reports menu to the new view
- document the manager summary page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685348a851908321a451b47f7cabbcca