### PR TITLE
Add user listing page

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -13,6 +13,7 @@ The application groups menu links by user role. A sidebar or top bar can surface
 
 ### For Admin / HR
 - **User Master** → `/user-master`
+- **User List** → `/users`
 - **Project Master** → `/project-master`
 - **Project Assignment** → `/project-assignment` (optional)
 - **Reports** → `/reports`
@@ -31,6 +32,7 @@ The application groups menu links by user role. A sidebar or top bar can surface
 | `/timesheet-entry` | Employees log hours; add rows and submit. |
 | `/timesheet-history` | Employee view of past time entries. |
 | `/user-master` | Admins add or edit users and project allocations. |
+| `/users` | List of all users with filters and search. |
 | `/project-master` | Admins and PMs define projects. |
 | `/project-overview` | PM view of project timelines and assignments. |
 | `/timesheet-approval` | PMs approve or reject submitted timesheets. |

--- a/templates/base_dashboard.html
+++ b/templates/base_dashboard.html
@@ -9,6 +9,7 @@
                 <li class="nav-item"><a class="nav-link" href="#">History</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('project_master') }}">Project Master</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('user_master') }}">User Master</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('users') }}">User List</a></li>
                 <li class="nav-item">
                     <a class="nav-link" data-bs-toggle="collapse" href="#reportsMenu" role="button" aria-expanded="false" aria-controls="reportsMenu">Reports</a>
                     <ul class="nav flex-column collapse ms-3" id="reportsMenu">

--- a/templates/user_list.html
+++ b/templates/user_list.html
@@ -1,0 +1,76 @@
+{% extends 'base_dashboard.html' %}
+{% block title %}Users{% endblock %}
+{% block content %}
+<h3 class="mb-4">List of Users</h3>
+<form method="get" class="row g-3 mb-3" id="filters">
+  <div class="col-md-3">
+    <input type="text" name="q" id="search" value="{{ search }}" class="form-control" placeholder="Search name or email">
+  </div>
+  <div class="col-md-2">
+    <select name="department" class="form-select" onchange="this.form.submit()">
+      <option value="">All Departments</option>
+      {% for d in departments %}
+      <option value="{{ d }}" {% if d == selected_department %}selected{% endif %}>{{ d }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-2">
+    <select name="role" class="form-select" onchange="this.form.submit()">
+      <option value="">All Roles</option>
+      {% for r in roles %}
+      <option value="{{ r }}" {% if r == selected_role %}selected{% endif %}>{{ r }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-2">
+    <select name="status" class="form-select" onchange="this.form.submit()">
+      <option value="">All Statuses</option>
+      {% for s in statuses %}
+      <option value="{{ s }}" {% if s == selected_status %}selected{% endif %}>{{ s }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</form>
+<table class="table table-striped" id="users-table">
+  <thead>
+    <tr>
+      <th>Full Name</th>
+      <th>Email</th>
+      <th>Department</th>
+      <th>Role</th>
+      <th>Status</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    <tr>
+      <td>{{ u.full_name }}</td>
+      <td>{{ u.email }}</td>
+      <td>{{ u.department }}</td>
+      <td>{{ u.role }}</td>
+      <td>{{ u.status }}</td>
+      <td>
+        <a href="{{ url_for('user_master') }}?id={{ u.id }}" class="btn btn-sm btn-outline-primary">Edit</a>
+        <a href="{{ url_for('deactivate_user', user_id=u.id) }}" class="btn btn-sm btn-outline-danger">Deactivate</a>
+        <a href="{{ url_for('view_profile', user_id=u.id) }}" class="btn btn-sm btn-outline-secondary">View</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<nav>
+  <ul class="pagination">
+    {% for p in range(1, total_pages + 1) %}
+    <li class="page-item {% if p == page %}active{% endif %}">
+      <a class="page-link" href="{{ url_for('users', page=p, q=search, department=selected_department, role=selected_role, status=selected_status) }}">{{ p }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+</nav>
+<script>
+document.getElementById('search').addEventListener('input', function(){
+  this.form.submit();
+});
+</script>
+{% endblock %}

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -1,0 +1,12 @@
+{% extends 'base_dashboard.html' %}
+{% block title %}Profile{% endblock %}
+{% block content %}
+<h3 class="mb-4">{{ user.full_name }}</h3>
+<ul class="list-group mb-3">
+  <li class="list-group-item"><strong>Email:</strong> {{ user.email }}</li>
+  <li class="list-group-item"><strong>Department:</strong> {{ user.department }}</li>
+  <li class="list-group-item"><strong>Role:</strong> {{ user.role }}</li>
+  <li class="list-group-item"><strong>Status:</strong> {{ user.status }}</li>
+</ul>
+<a href="{{ url_for('users') }}" class="btn btn-secondary">Back to List</a>
+{% endblock %}

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,5 +1,6 @@
 import unittest
 from web_app import app
+import timesheet
 from flask import session
 
 class LogoutTests(unittest.TestCase):
@@ -20,6 +21,31 @@ class LogoutTests(unittest.TestCase):
         with self.client.session_transaction() as sess:
             self.assertNotIn('employee', sess)
             self.assertNotIn('role', sess)
+
+
+class UsersPageTests(unittest.TestCase):
+    def setUp(self):
+        app.config['TESTING'] = True
+        self.client = app.test_client()
+
+        # add a sample user
+        with app.app_context():
+            with timesheet.connect_db() as conn:
+                cur = conn.cursor()
+                cur.execute(
+                    "INSERT INTO users (full_name, email, username, password, department, role, status) "
+                    "VALUES ('Test User', 'test@example.com', 'testuser', 'x', 'IT', 'Employee', 'Active')"
+                )
+                conn.commit()
+
+    def test_users_page_loads(self):
+        with self.client.session_transaction() as sess:
+            sess['employee'] = 'Admin'
+            sess['role'] = 'Admin'
+
+        response = self.client.get('/users')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Test User', response.data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add sidebar link to new **User List** page
- document `/users` route in navigation docs
- implement paginated user list with search and filtering
- support deactivating accounts and viewing a basic profile
- test that user list page renders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68534ffb6cbc83218aab3009b8a1a380