### PR TITLE
Ensure project master entries show in timesheet dropdown

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -28,7 +28,12 @@ def fetch_projects():
     try:
         with timesheet.connect_db() as conn:
             cur = conn.cursor()
-            cur.execute('SELECT name FROM projects ORDER BY name')
+            # Include project names from both the legacy ``projects`` table
+            # and the newer ``project_master`` table to ensure dropdowns
+            # show all available projects.
+            cur.execute(
+                "SELECT name FROM projects UNION SELECT project_name FROM project_master ORDER BY 1"
+            )
             return [row[0] for row in cur.fetchall()]
     except sqlite3.Error:
         return []


### PR DESCRIPTION
## Summary
- show projects from both `projects` and `project_master` tables in dropdowns
- test that timesheet form includes project master entries

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68539e931b348321a60acf2fb915a6be